### PR TITLE
Fix search bar offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Put this into your QuickCSS (Or any non-Vencord equivalent) to configure some be
 }
 ```
 ### --vr-header-snippet-space cheat sheet
-Try these if you dont want to find out the spacing yourself!
+Try these if you don't want to find out the spacing yourself!
 
 - Desktop Default: 180px
 - Desktop Spacious UI Scaling: 200px

--- a/desktop.css
+++ b/desktop.css
@@ -118,7 +118,7 @@
     /* Move search bar to fit new layout */
     div.searchBar__1ac1c {
         position: relative;
-        right: 220px;
+        right: var(--vr-header-snippet-space);
     }
 
     /* === UPDATE: Fix top bar size when notice appears === */


### PR DESCRIPTION
## Summary
- correct README typo in configuration section
- use variable for search bar offset so theme spacing works with custom values

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d64b5a92c832ea6edbc2cce40c0ed